### PR TITLE
move interrupt vector table to interruptmanager

### DIFF
--- a/include/kernel/devicemanager.h
+++ b/include/kernel/devicemanager.h
@@ -13,21 +13,16 @@ namespace kernel
 class DeviceManager 
 {
 protected:
-    InterruptHandler* handlers[256];
     driver::Keyboard keyboard;
     driver::Timer timer;
     driver::Mouse mouse;
 public:
 
-  public:
     DeviceManager();
     ~DeviceManager();
 
     void initialize();
-
-public:
-    void registerDevice(InterruptHandler *handler);
-    void handleInterrupt(uint8 vector);
+    void registerInterrupt(InterruptHandler *handler);
 };
 
 }

--- a/include/kernel/interruptmanager.h
+++ b/include/kernel/interruptmanager.h
@@ -48,12 +48,13 @@ public:
     void initialize();
 	void* getIDTAddress();
 
+	void registerInterrupt(InterruptHandler *handler);
 	void exceptionHandle(uint64 vector);
 
 protected:
 	void setupIDT();
 	void setGateEntry(uint8 vector, void* irs, uint8 flags);
-
+    InterruptHandler* handlers[256];
 };
 
 }

--- a/kernel/devicemanager.cpp
+++ b/kernel/devicemanager.cpp
@@ -2,6 +2,8 @@
 #include <kernel/printer.h>
 #include <kernel/iocommand.h>
 
+#include <kernel/kernel.h>
+
 using namespace kernel;
 
 DeviceManager::DeviceManager() {
@@ -16,15 +18,11 @@ void DeviceManager::initialize() {
     keyboard.active();
     timer.active();
     mouse.active();
-    this->registerDevice(&timer);
-    this->registerDevice(&keyboard);
-    this->registerDevice(&mouse);
+    this->registerInterrupt(&timer);
+    this->registerInterrupt(&keyboard);
+    this->registerInterrupt(&mouse);
 }
 
-void DeviceManager::registerDevice(InterruptHandler *handler) {
-    this->handlers[handler->getVector()] = handler;
-}
-
-void DeviceManager::handleInterrupt(uint8 vector) {
-    this->handlers[vector]->handleInterrupt();
+void DeviceManager::registerInterrupt(InterruptHandler *handler) {
+    Kernel::getInstance()->getInterruptManager()->registerInterrupt(handler);
 }

--- a/kernel/interruptmanager.cpp
+++ b/kernel/interruptmanager.cpp
@@ -115,10 +115,14 @@ void* InterruptManager::getIDTAddress()
     return this->idt;
 }
 
+void InterruptManager::registerInterrupt(InterruptHandler *handler) {
+    this->handlers[handler->getVector()] = handler;
+}
+
 // This function need to be called in Kernel main thread
 void InterruptManager::exceptionHandle(uint64 vector)
 {
-    Kernel::getInstance()->getDeviceManager()->handleInterrupt(vector);
+    this->handlers[vector]->handleInterrupt();
     if (vector - OFFSET <= 8)
     {
         outb(0xA0, 0x20);


### PR DESCRIPTION
Interrupt vector table should  be manage by InterruptManager instead of DeviceManager