### PR TITLE
add a flag for adding debug symbol correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,11 @@ CXXFLAGS += -mgeneral-regs-only
 CXXFLAGS += -MMD
 CXXFLAGS += -O0
 CXXFLAGS += -mno-red-zone
+CXXFLAGS += -g
 
 ASFLAGS = -felf64 
 
-LDFLAGS = -T kernel.ld -nostdlib -n -g
+LDFLAGS = -T kernel.ld -nostdlib -n
 LDFLAGS += -Map=$(MAP)
 
 


### PR DESCRIPTION
Hello, 
I saw that you put -g flag wrong place, I made it to be correct.
before 
`readelf -S build/kernel.bin | grep debug` -> nothing

after :
```
└─[0] <> readelf -S build/kernel.bin | grep debug
  [84] .debug_info       PROGBITS         0000000000000000  0000d380
  [85] .debug_abbrev     PROGBITS         0000000000000000  0001b8d6
  [86] .debug_aranges    PROGBITS         0000000000000000  0001f997
  [87] .debug_line       PROGBITS         0000000000000000  00020297
  [88] .debug_str        PROGBITS         0000000000000000  00023edd
  [89] .debug_line_str   PROGBITS         0000000000000000  000289de
  [91] .debug_rnglists   PROGBITS         0000000000000000  00028dc2
```